### PR TITLE
fix: improve TypeScript type safety in useAgroSafe hook

### DIFF
--- a/agrosafe-frontend/src/hooks/useAgroSafe.tsx
+++ b/agrosafe-frontend/src/hooks/useAgroSafe.tsx
@@ -1,9 +1,9 @@
 import AgroSafeABI from "../abi/AgroSafe.json";
 import { usePublicClient, useWalletClient } from "wagmi";
-import { parseAbi, Address } from "viem";
+import { parseAbi, Address, Abi } from "viem";
 
 const CONTRACT_ADDRESS = (import.meta.env.VITE_AGROSAFE_ADDRESS as string) || "";
-const PARSED_ABI = parseAbi(AgroSafeABI as any);
+const PARSED_ABI = parseAbi(AgroSafeABI as unknown as Abi);
 
 export type Farmer = {
     id: number;


### PR DESCRIPTION
- Changed 'as any' to 'as unknown as Abi' for better type safety
- Added proper Abi type import from viem
- This ensures the ABI is properly typed during compilation